### PR TITLE
Update labels to make them unique from csharp-dotnet-samples

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 def ENV_LOC=[:]
 pipeline {
     parameters {
-        choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-dotnet-samples', 'linux-dotnet-samples', 'mac-arm-dotnet-samples', 'mac-intel-dotnet-samples','linux-arm-dotnet-samples'], description: 'Run on specific platform')
+        choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-vb-dotnet-samples', 'linux-vb-dotnet-samples', 'mac-arm-vb-dotnet-samples', 'mac-intel-vb-dotnet-samples','linux-arm-vb-dotnet-samples'], description: 'Run on specific platform')
         booleanParam defaultValue: false, description: 'Completely clean the workspace before building, including the Conan cache', name: 'CLEAN_WORKSPACE'
         booleanParam defaultValue: false, description: 'Run clean-samples', name: 'DISTCLEAN'
         booleanParam defaultValue: true, description: 'Run clean-nuget-cache', name: 'NUGETCLEAN'
@@ -32,7 +32,7 @@ pipeline {
                 axes {
                     axis {
                         name 'NODE'
-                        values 'windows-dotnet-samples', 'linux-dotnet-samples', 'mac-arm-dotnet-samples', 'mac-intel-dotnet-samples','linux-arm-dotnet-samples'
+                        values 'windows-vb-dotnet-samples', 'linux-vb-dotnet-samples', 'mac-arm-vb-dotnet-samples', 'mac-intel-vb-dotnet-samples','linux-arm-vb-dotnet-samples'
                     }
                 }
                 environment {


### PR DESCRIPTION
We always want the samples to run on different machines. This prevents collisions when NUGETCLEAN executes.