### PR TITLE
Separate APDFL 18 NuGet Packages from 21

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -191,11 +191,11 @@ def get_public_packages():
 def get_nightly_packages():
     """Locations of nightly packages. Note: These paths will only work on the nuget-builder build machine"""
     if platform.system() == 'Darwin':
-        libraryPackagePath = '/Volumes/raid/nuget-builder-samples-test'
+        libraryPackagePath = '/Volumes/raid/nuget-builder-samples-test-18'
     elif platform.system() == 'Windows':
-        libraryPackagePath = '\\\\ivy\\raid\\nuget-builder-samples-test'
+        libraryPackagePath = '\\\\ivy\\raid\\nuget-builder-samples-test-18'
     else:
-        libraryPackagePath = '/raid/nuget-builder-samples-test'
+        libraryPackagePath = '/raid/nuget-builder-samples-test-18'
 
     libraryPackages = [os.path.join(libraryPackagePath, item) for item in os.listdir(libraryPackagePath)]
 


### PR DESCRIPTION
Create a new directory for the APDFL 18 nuget packages so that they don't overwrite the APDFL 21 packages.