### PR TITLE
APDFL-6789: Update samples for APDFL 21

### DIFF
--- a/Annotations/Annotations/Annotations.vbproj
+++ b/Annotations/Annotations/Annotations.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Annotations/Annotations/Annotations.vbproj
+++ b/Annotations/Annotations/Annotations.vbproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 		<PackageReference Include="Adobe.PDF.Library.SampleInput" Version="1.*" />
 	</ItemGroup>
 

--- a/Annotations/InkAnnotations/InkAnnotations.vbproj
+++ b/Annotations/InkAnnotations/InkAnnotations.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Annotations/InkAnnotations/InkAnnotations.vbproj
+++ b/Annotations/InkAnnotations/InkAnnotations.vbproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 	</ItemGroup>
 
 </Project>

--- a/Annotations/LinkAnnotation/LinkAnnotation.vbproj
+++ b/Annotations/LinkAnnotation/LinkAnnotation.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Annotations/LinkAnnotation/LinkAnnotation.vbproj
+++ b/Annotations/LinkAnnotation/LinkAnnotation.vbproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 	</ItemGroup>
 
 </Project>

--- a/Annotations/PolyLineAnnotations/PolyLineAnnotations.vbproj
+++ b/Annotations/PolyLineAnnotations/PolyLineAnnotations.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Annotations/PolyLineAnnotations/PolyLineAnnotations.vbproj
+++ b/Annotations/PolyLineAnnotations/PolyLineAnnotations.vbproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 	</ItemGroup>
 
 </Project>

--- a/Annotations/PolygonAnnotations/PolygonAnnotations.vbproj
+++ b/Annotations/PolygonAnnotations/PolygonAnnotations.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/Annotations/PolygonAnnotations/PolygonAnnotations.vbproj
+++ b/Annotations/PolygonAnnotations/PolygonAnnotations.vbproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 	</ItemGroup>
 
 </Project>

--- a/ContentCreation/AddHeaderFooter/AddHeaderFooter.vbproj
+++ b/ContentCreation/AddHeaderFooter/AddHeaderFooter.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentCreation/AddHeaderFooter/AddHeaderFooter.vbproj
+++ b/ContentCreation/AddHeaderFooter/AddHeaderFooter.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/Clips/Clips.vbproj
+++ b/ContentCreation/Clips/Clips.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentCreation/Clips/Clips.vbproj
+++ b/ContentCreation/Clips/Clips.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>Clips</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ContentCreation/CreateBookmarks/CreateBookmarks.vbproj
+++ b/ContentCreation/CreateBookmarks/CreateBookmarks.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentCreation/CreateBookmarks/CreateBookmarks.vbproj
+++ b/ContentCreation/CreateBookmarks/CreateBookmarks.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/Action/Action.vbproj
+++ b/ContentModification/Action/Action.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentModification/Action/Action.vbproj
+++ b/ContentModification/Action/Action.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+	<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/AddCollection/AddCollection.vbproj
+++ b/ContentModification/AddCollection/AddCollection.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentModification/AddCollection/AddCollection.vbproj
+++ b/ContentModification/AddCollection/AddCollection.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/AddQRCode/AddQRCode.vbproj
+++ b/ContentModification/AddQRCode/AddQRCode.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentModification/AddQRCode/AddQRCode.vbproj
+++ b/ContentModification/AddQRCode/AddQRCode.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/ChangeLayerConfiguration/ChangeLayerConfiguration.vbproj
+++ b/ContentModification/ChangeLayerConfiguration/ChangeLayerConfiguration.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentModification/ChangeLayerConfiguration/ChangeLayerConfiguration.vbproj
+++ b/ContentModification/ChangeLayerConfiguration/ChangeLayerConfiguration.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+	<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/ChangeLinkColors/ChangeLinkColors.vbproj
+++ b/ContentModification/ChangeLinkColors/ChangeLinkColors.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>ChangeLinkColors</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ContentModification/ChangeLinkColors/ChangeLinkColors.vbproj
+++ b/ContentModification/ChangeLinkColors/ChangeLinkColors.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/CreateLayer/CreateLayer.vbproj
+++ b/ContentModification/CreateLayer/CreateLayer.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentModification/CreateLayer/CreateLayer.vbproj
+++ b/ContentModification/CreateLayer/CreateLayer.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+	<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/ExtendedGraphicStates/ExtendedGraphicStates.vbproj
+++ b/ContentModification/ExtendedGraphicStates/ExtendedGraphicStates.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentModification/ExtendedGraphicStates/ExtendedGraphicStates.vbproj
+++ b/ContentModification/ExtendedGraphicStates/ExtendedGraphicStates.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+	<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/FlattenTransparency/FlattenTransparency.vbproj
+++ b/ContentModification/FlattenTransparency/FlattenTransparency.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentModification/FlattenTransparency/FlattenTransparency.vbproj
+++ b/ContentModification/FlattenTransparency/FlattenTransparency.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/LaunchActions/LaunchActions.vbproj
+++ b/ContentModification/LaunchActions/LaunchActions.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentModification/LaunchActions/LaunchActions.vbproj
+++ b/ContentModification/LaunchActions/LaunchActions.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/MergePDF/MergePDF.vbproj
+++ b/ContentModification/MergePDF/MergePDF.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentModification/MergePDF/MergePDF.vbproj
+++ b/ContentModification/MergePDF/MergePDF.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/PDFObject/PDFObject.vbproj
+++ b/ContentModification/PDFObject/PDFObject.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentModification/PDFObject/PDFObject.vbproj
+++ b/ContentModification/PDFObject/PDFObject.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/PageLabels/PageLabels.vbproj
+++ b/ContentModification/PageLabels/PageLabels.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentModification/PageLabels/PageLabels.vbproj
+++ b/ContentModification/PageLabels/PageLabels.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/UnderlinesAndHighlights/UnderlinesAndHighlights.vbproj
+++ b/ContentModification/UnderlinesAndHighlights/UnderlinesAndHighlights.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentModification/UnderlinesAndHighlights/UnderlinesAndHighlights.vbproj
+++ b/ContentModification/UnderlinesAndHighlights/UnderlinesAndHighlights.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/ContentModification/Watermark/Watermark.vbproj
+++ b/ContentModification/Watermark/Watermark.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/ContentModification/Watermark/Watermark.vbproj
+++ b/ContentModification/Watermark/Watermark.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentConversion/ColorConvertDocument/ColorConvertDocument.vbproj
+++ b/DocumentConversion/ColorConvertDocument/ColorConvertDocument.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/DocumentConversion/ColorConvertDocument/ColorConvertDocument.vbproj
+++ b/DocumentConversion/ColorConvertDocument/ColorConvertDocument.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentConversion/ConvertToOffice/ConvertToOffice.vbproj
+++ b/DocumentConversion/ConvertToOffice/ConvertToOffice.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Platforms>x64</Platforms>

--- a/DocumentConversion/ConvertToOffice/ConvertToOffice.vbproj
+++ b/DocumentConversion/ConvertToOffice/ConvertToOffice.vbproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentConversion/CreateDocFromXPS/CreateDocFromXPS.vbproj
+++ b/DocumentConversion/CreateDocFromXPS/CreateDocFromXPS.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/DocumentConversion/CreateDocFromXPS/CreateDocFromXPS.vbproj
+++ b/DocumentConversion/CreateDocFromXPS/CreateDocFromXPS.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentConversion/FacturXConverter/FacturXConverter.vbproj
+++ b/DocumentConversion/FacturXConverter/FacturXConverter.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/DocumentConversion/FacturXConverter/FacturXConverter.vbproj
+++ b/DocumentConversion/FacturXConverter/FacturXConverter.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentConversion/PDFAConverter/PDFAConverter.vbproj
+++ b/DocumentConversion/PDFAConverter/PDFAConverter.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/DocumentConversion/PDFAConverter/PDFAConverter.vbproj
+++ b/DocumentConversion/PDFAConverter/PDFAConverter.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentConversion/PDFXConverter/PDFXConverter.vbproj
+++ b/DocumentConversion/PDFXConverter/PDFXConverter.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/DocumentConversion/PDFXConverter/PDFXConverter.vbproj
+++ b/DocumentConversion/PDFXConverter/PDFXConverter.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentConversion/ZUGFeRDConverter/ZUGFeRDConverter.vbproj
+++ b/DocumentConversion/ZUGFeRDConverter/ZUGFeRDConverter.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/DocumentConversion/ZUGFeRDConverter/ZUGFeRDConverter.vbproj
+++ b/DocumentConversion/ZUGFeRDConverter/ZUGFeRDConverter.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/DocumentOptimization/PDFOptimize/PDFOptimize.vbproj
+++ b/DocumentOptimization/PDFOptimize/PDFOptimize.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/DocumentOptimization/PDFOptimize/PDFOptimize.vbproj
+++ b/DocumentOptimization/PDFOptimize/PDFOptimize.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Images/DocToImages/DocToImages.vbproj
+++ b/Images/DocToImages/DocToImages.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/Images/DocToImages/DocToImages.vbproj
+++ b/Images/DocToImages/DocToImages.vbproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 	</ItemGroup>
 
 </Project>

--- a/Images/DrawSeparations/DrawSeparations.vbproj
+++ b/Images/DrawSeparations/DrawSeparations.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/Images/DrawSeparations/DrawSeparations.vbproj
+++ b/Images/DrawSeparations/DrawSeparations.vbproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 		<PackageReference Include="SkiaSharp" Version="3.119.*" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.*" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.*" />

--- a/Images/DrawToBitmap/DrawToBitmap.vbproj
+++ b/Images/DrawToBitmap/DrawToBitmap.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/Images/DrawToBitmap/DrawToBitmap.vbproj
+++ b/Images/DrawToBitmap/DrawToBitmap.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
     <PackageReference Include="SkiaSharp" Version="3.119.*" />
     <PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.*" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.*" />

--- a/Images/EPSSeparations/EPSSeparations.vbproj
+++ b/Images/EPSSeparations/EPSSeparations.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/Images/EPSSeparations/EPSSeparations.vbproj
+++ b/Images/EPSSeparations/EPSSeparations.vbproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 	</ItemGroup>
 
 </Project>

--- a/Images/GetSeparatedImages/GetSeparatedImages.vbproj
+++ b/Images/GetSeparatedImages/GetSeparatedImages.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/Images/GetSeparatedImages/GetSeparatedImages.vbproj
+++ b/Images/GetSeparatedImages/GetSeparatedImages.vbproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 	</ItemGroup>
 
 </Project>

--- a/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.vbproj
+++ b/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.vbproj
+++ b/Images/ImageEmbedICCProfile/ImageEmbedICCProfile.vbproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 	</ItemGroup>
 
 </Project>

--- a/Images/ImageExport/ImageExport.vbproj
+++ b/Images/ImageExport/ImageExport.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/Images/ImageExport/ImageExport.vbproj
+++ b/Images/ImageExport/ImageExport.vbproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 	</ItemGroup>
 
 </Project>

--- a/Images/ImageExtraction/ImageExtraction.vbproj
+++ b/Images/ImageExtraction/ImageExtraction.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/Images/ImageExtraction/ImageExtraction.vbproj
+++ b/Images/ImageExtraction/ImageExtraction.vbproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 		<PackageReference Include="SkiaSharp" Version="3.119.*" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.*" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.*" />

--- a/Images/ImageFromStream/ImageFromStream.vbproj
+++ b/Images/ImageFromStream/ImageFromStream.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/Images/ImageFromStream/ImageFromStream.vbproj
+++ b/Images/ImageFromStream/ImageFromStream.vbproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 		<PackageReference Include="SkiaSharp" Version="3.119.*" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.*" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.*" />

--- a/Images/ImageImport/ImageImport.vbproj
+++ b/Images/ImageImport/ImageImport.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/Images/ImageImport/ImageImport.vbproj
+++ b/Images/ImageImport/ImageImport.vbproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 	</ItemGroup>
 
 </Project>

--- a/Images/ImageResampling/ImageResampling.vbproj
+++ b/Images/ImageResampling/ImageResampling.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/Images/ImageResampling/ImageResampling.vbproj
+++ b/Images/ImageResampling/ImageResampling.vbproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 	</ItemGroup>
 
 </Project>

--- a/Images/ImageSoftMask/ImageSoftMask.vbproj
+++ b/Images/ImageSoftMask/ImageSoftMask.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/Images/ImageSoftMask/ImageSoftMask.vbproj
+++ b/Images/ImageSoftMask/ImageSoftMask.vbproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 	</ItemGroup>
 
 </Project>

--- a/Images/OutputPreview/OutputPreview.vbproj
+++ b/Images/OutputPreview/OutputPreview.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/Images/OutputPreview/OutputPreview.vbproj
+++ b/Images/OutputPreview/OutputPreview.vbproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 	</ItemGroup>
 
 </Project>

--- a/Images/RasterizePage/RasterizePage.vbproj
+++ b/Images/RasterizePage/RasterizePage.vbproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>
 

--- a/Images/RasterizePage/RasterizePage.vbproj
+++ b/Images/RasterizePage/RasterizePage.vbproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+		<PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
 		<PackageReference Include="SkiaSharp" Version="3.119.*" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Win32" Version="3.119.*" />
 		<PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.*" />

--- a/InformationExtraction/ListBookmarks/ListBookmarks.vbproj
+++ b/InformationExtraction/ListBookmarks/ListBookmarks.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/InformationExtraction/ListBookmarks/ListBookmarks.vbproj
+++ b/InformationExtraction/ListBookmarks/ListBookmarks.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>ListBookmarks</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/InformationExtraction/ListInfo/ListInfo.vbproj
+++ b/InformationExtraction/ListInfo/ListInfo.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/InformationExtraction/ListInfo/ListInfo.vbproj
+++ b/InformationExtraction/ListInfo/ListInfo.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>ListInfo</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/InformationExtraction/ListLayers/ListLayers.vbproj
+++ b/InformationExtraction/ListLayers/ListLayers.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>ListLayers</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/InformationExtraction/ListLayers/ListLayers.vbproj
+++ b/InformationExtraction/ListLayers/ListLayers.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/InformationExtraction/ListPaths/ListPaths.vbproj
+++ b/InformationExtraction/ListPaths/ListPaths.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>ListPaths</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/InformationExtraction/ListPaths/ListPaths.vbproj
+++ b/InformationExtraction/ListPaths/ListPaths.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/InformationExtraction/Metadata/Metadata.vbproj
+++ b/InformationExtraction/Metadata/Metadata.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>Metadata</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/InformationExtraction/Metadata/Metadata.vbproj
+++ b/InformationExtraction/Metadata/Metadata.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 def ENV_LOC=[:]
 pipeline {
     parameters {
-        choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-dotnet-samples', 'linux-dotnet-samples', 'mac-arm-dotnet-samples', 'mac-intel-dotnet-samples','linux-arm-dotnet-samples'], description: 'Run on specific platform')
+        choice(name: 'PLATFORM_FILTER', choices: ['all', 'windows-dotnet-samples', 'rocky9-dotnet-samples', 'mac-arm-dotnet-samples', 'mac-intel-dotnet-samples', 'rocky9-arm-dotnet-samples'], description: 'Run on specific platform')
         booleanParam defaultValue: false, description: 'Completely clean the workspace before building, including the Conan cache', name: 'CLEAN_WORKSPACE'
         booleanParam defaultValue: false, description: 'Run clean-samples', name: 'DISTCLEAN'
         booleanParam defaultValue: true, description: 'Run clean-nuget-cache', name: 'NUGETCLEAN'
@@ -17,7 +17,7 @@ pipeline {
         // Run branches between 0800 and 0830, depending on a hash of the job name
         // This means if there's more than one branch (a feature branch, maybe?), they
         // won't all start at the same time.
-        cron(env.BRANCH_NAME == "develop-18" ? 'H(0-30) 7 * * *' : '')
+        cron(env.BRANCH_NAME == "develop-21" ? 'H(0-30) 8 * * *' : '')
     }
     stages {
         stage('Matrix stage') {
@@ -32,7 +32,7 @@ pipeline {
                 axes {
                     axis {
                         name 'NODE'
-                        values 'windows-dotnet-samples', 'linux-dotnet-samples', 'mac-arm-dotnet-samples', 'mac-intel-dotnet-samples','linux-arm-dotnet-samples'
+                        values 'windows-dotnet-samples', 'rocky9-dotnet-samples', 'mac-arm-dotnet-samples', 'mac-intel-dotnet-samples','rocky9-arm-dotnet-samples'
                     }
                 }
                 stages {

--- a/OpticalCharacterRecognition/AddTextToDocument/AddTextToDocument.vbproj
+++ b/OpticalCharacterRecognition/AddTextToDocument/AddTextToDocument.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/OpticalCharacterRecognition/AddTextToDocument/AddTextToDocument.vbproj
+++ b/OpticalCharacterRecognition/AddTextToDocument/AddTextToDocument.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/OpticalCharacterRecognition/AddTextToImage/AddTextToImage.vbproj
+++ b/OpticalCharacterRecognition/AddTextToImage/AddTextToImage.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/OpticalCharacterRecognition/AddTextToImage/AddTextToImage.vbproj
+++ b/OpticalCharacterRecognition/AddTextToImage/AddTextToImage.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/OpticalCharacterRecognition/OCRDocument/OCRDocument.vbproj
+++ b/OpticalCharacterRecognition/OCRDocument/OCRDocument.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/OpticalCharacterRecognition/OCRDocument/OCRDocument.vbproj
+++ b/OpticalCharacterRecognition/OCRDocument/OCRDocument.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Other/MemoryFileSystem/MemoryFileSystem.vbproj
+++ b/Other/MemoryFileSystem/MemoryFileSystem.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Other/MemoryFileSystem/MemoryFileSystem.vbproj
+++ b/Other/MemoryFileSystem/MemoryFileSystem.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Other/StreamIO/StreamIO.vbproj
+++ b/Other/StreamIO/StreamIO.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Other/StreamIO/StreamIO.vbproj
+++ b/Other/StreamIO/StreamIO.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Datalogics Adobe PDF Library](https://raw.github.com/datalogics/dl-icons/develop/DLBanner_Nuget.png)
 
-[Documentation](https://dev.datalogics.com/adobe-pdf-library/dot-net/getting-started) &nbsp;| [API Reference](https://docs.datalogics.com/apdfl18/DotNet/) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://dev.datalogics.com/adobe-pdf-library/release-notes) &nbsp; | &nbsp;[Discord](https://discord.gg/jNSHcSdRre)
+[Documentation](https://dev.datalogics.com/adobe-pdf-library-21/dot-net/getting-started) &nbsp;| [API Reference](https://docs.datalogics.com/apdfl21/DotNet/) &nbsp;|&nbsp; [Support](https://www.datalogics.com/tech-support-pdfs/) &nbsp; | &nbsp; [Release Notes](https://dev.datalogics.com/adobe-pdf-library-21/release-notes) &nbsp; | &nbsp;[Discord](https://discord.gg/jNSHcSdRre)
 
 [![Download a Free Trial on NuGet](https://img.shields.io/nuget/dt/Adobe.PDF.Library.LM.NET?color=blue&label=APDFL%20.NET%20Free%20Trial&logo=NuGet&style=plastic)](https://www.nuget.org/packages/Adobe.PDF.Library.LM.NET)
 

--- a/Security/AddBasicPAdESElectronicSignature/AddBasicPAdESElectronicSignature.vbproj
+++ b/Security/AddBasicPAdESElectronicSignature/AddBasicPAdESElectronicSignature.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Security/AddBasicPAdESElectronicSignature/AddBasicPAdESElectronicSignature.vbproj
+++ b/Security/AddBasicPAdESElectronicSignature/AddBasicPAdESElectronicSignature.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Security/AddDigitalSignatureCMS/AddDigitalSignatureCMS.vbproj
+++ b/Security/AddDigitalSignatureCMS/AddDigitalSignatureCMS.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Security/AddDigitalSignatureCMS/AddDigitalSignatureCMS.vbproj
+++ b/Security/AddDigitalSignatureCMS/AddDigitalSignatureCMS.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Security/AddDigitalSignatureRFC3161/AddDigitalSignatureRFC3161.vbproj
+++ b/Security/AddDigitalSignatureRFC3161/AddDigitalSignatureRFC3161.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Security/AddDigitalSignatureRFC3161/AddDigitalSignatureRFC3161.vbproj
+++ b/Security/AddDigitalSignatureRFC3161/AddDigitalSignatureRFC3161.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Security/AddPAdESPolicySignature/AddPAdESPolicySignature.vbproj
+++ b/Security/AddPAdESPolicySignature/AddPAdESPolicySignature.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Security/AddPAdESPolicySignature/AddPAdESPolicySignature.vbproj
+++ b/Security/AddPAdESPolicySignature/AddPAdESPolicySignature.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Security/AddRegexRedaction/AddRegexRedaction.vbproj
+++ b/Security/AddRegexRedaction/AddRegexRedaction.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Security/AddRegexRedaction/AddRegexRedaction.vbproj
+++ b/Security/AddRegexRedaction/AddRegexRedaction.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Security/Redactions/Redactions.vbproj
+++ b/Security/Redactions/Redactions.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Security/Redactions/Redactions.vbproj
+++ b/Security/Redactions/Redactions.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/AddGlyphs/AddGlyphs.vbproj
+++ b/Text/AddGlyphs/AddGlyphs.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/AddGlyphs/AddGlyphs.vbproj
+++ b/Text/AddGlyphs/AddGlyphs.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>AddGlyphs</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Text/AddUnicodeText/AddUnicodeText.vbproj
+++ b/Text/AddUnicodeText/AddUnicodeText.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/AddUnicodeText/AddUnicodeText.vbproj
+++ b/Text/AddUnicodeText/AddUnicodeText.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>AddUnicodeText</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Text/AddVerticalText/AddVerticalText.vbproj
+++ b/Text/AddVerticalText/AddVerticalText.vbproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/AddVerticalText/AddVerticalText.vbproj
+++ b/Text/AddVerticalText/AddVerticalText.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>AddVerticalText</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Text/ExtractAcroFormFieldData/ExtractAcroFormFieldData.vbproj
+++ b/Text/ExtractAcroFormFieldData/ExtractAcroFormFieldData.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../../_Common/ExtractText.vb" Link="ExtractText.vb" />

--- a/Text/ExtractAcroFormFieldData/ExtractAcroFormFieldData.vbproj
+++ b/Text/ExtractAcroFormFieldData/ExtractAcroFormFieldData.vbproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>ExtractAcroFormFieldData</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/Text/ExtractTextFromAnnotations/ExtractTextFromAnnotations.vbproj
+++ b/Text/ExtractTextFromAnnotations/ExtractTextFromAnnotations.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Text/ExtractTextFromAnnotations/ExtractTextFromAnnotations.vbproj
+++ b/Text/ExtractTextFromAnnotations/ExtractTextFromAnnotations.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../../_Common/ExtractText.vb" Link="ExtractText.vb" />

--- a/Text/ExtractTextFromMultiRegions/ExtractTextFromMultiRegions.vbproj
+++ b/Text/ExtractTextFromMultiRegions/ExtractTextFromMultiRegions.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Text/ExtractTextFromMultiRegions/ExtractTextFromMultiRegions.vbproj
+++ b/Text/ExtractTextFromMultiRegions/ExtractTextFromMultiRegions.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../../_Common/ExtractText.vb" Link="ExtractText.vb" />

--- a/Text/ExtractTextPreservingStyleAndPositionInfo/ExtractTextPreservingStyleAndPositionInfo.vbproj
+++ b/Text/ExtractTextPreservingStyleAndPositionInfo/ExtractTextPreservingStyleAndPositionInfo.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Text/ExtractTextPreservingStyleAndPositionInfo/ExtractTextPreservingStyleAndPositionInfo.vbproj
+++ b/Text/ExtractTextPreservingStyleAndPositionInfo/ExtractTextPreservingStyleAndPositionInfo.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="../../_Common/ExtractText.vb" Link="ExtractText.vb" />

--- a/Text/ListWords/ListWords.vbproj
+++ b/Text/ListWords/ListWords.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Text/ListWords/ListWords.vbproj
+++ b/Text/ListWords/ListWords.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/RegexExtractText/RegexExtractText.vbproj
+++ b/Text/RegexExtractText/RegexExtractText.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Text/RegexExtractText/RegexExtractText.vbproj
+++ b/Text/RegexExtractText/RegexExtractText.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/RegexTextSearch/RegexTextSearch.vbproj
+++ b/Text/RegexTextSearch/RegexTextSearch.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Text/RegexTextSearch/RegexTextSearch.vbproj
+++ b/Text/RegexTextSearch/RegexTextSearch.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/Text/TextExtract/TextExtract.vbproj
+++ b/Text/TextExtract/TextExtract.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Text/TextExtract/TextExtract.vbproj
+++ b/Text/TextExtract/TextExtract.vbproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="18.*" />
+    <PackageReference Include="Adobe.PDF.Library.LM.NET" Version="21.*" />
   </ItemGroup>
 
 </Project>

--- a/tasks.py
+++ b/tasks.py
@@ -174,14 +174,14 @@ def copy_packages_locally(libraryPackages):
 def get_public_packages():
     """Locations of packages that are live"""
     if platform.system() == 'Darwin':
-        libraryPackagePath = '/Volumes/raid/products/released/APDFL/nuget/DotNET/for_apdfl_18.0.5Plus/approved/current'
-        sampleInputPackagePath = '/Volumes/raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_18.0.5Plus/approved/current'
+        libraryPackagePath = '/Volumes/raid/products/released/APDFL/nuget/DotNET/for_apdfl_21.0.0Plus/approved/current'
+        sampleInputPackagePath = '/Volumes/raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_21.0.0Plus/approved/current'
     elif platform.system() == 'Windows':
-        libraryPackagePath = '\\\\ivy\\raid\\products\\released\\APDFL\\nuget\\DotNET\\for_apdfl_18.0.5Plus\\approved\\current'
-        sampleInputPackagePath = '\\\\ivy\\raid\\products\\released\\APDFL\\nuget\\SampleInputFile\\for_apdfl_18.0.5Plus\\approved\\current'
+        libraryPackagePath = '\\\\ivy\\raid\\products\\released\\APDFL\\nuget\\DotNET\\for_apdfl_21.0.0Plus\\approved\\current'
+        sampleInputPackagePath = '\\\\ivy\\raid\\products\\released\\APDFL\\nuget\\SampleInputFile\\for_apdfl_21.0.0Plus\\approved\\current'
     else:
-        libraryPackagePath = '/raid/products/released/APDFL/nuget/DotNET/for_apdfl_18.0.5Plus/approved/current'
-        sampleInputPackagePath = '/raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_18.0.5Plus/approved/current'
+        libraryPackagePath = '/raid/products/released/APDFL/nuget/DotNET/for_apdfl_21.0.0Plus/approved/current'
+        sampleInputPackagePath = '/raid/products/released/APDFL/nuget/SampleInputFile/for_apdfl_21.0.0Plus/approved/current'
 
     sampleInputPackages = [os.path.join(sampleInputPackagePath, item) for item in os.listdir(sampleInputPackagePath)]
 
@@ -191,11 +191,11 @@ def get_public_packages():
 def get_nightly_packages():
     """Locations of nightly packages. Note: These paths will only work on the nuget-builder build machine"""
     if platform.system() == 'Darwin':
-        libraryPackagePath = '/Volumes/raid/nuget-builder-samples-test-18'
+        libraryPackagePath = '/Volumes/raid/nuget-builder-samples-test'
     elif platform.system() == 'Windows':
-        libraryPackagePath = '\\\\ivy\\raid\\nuget-builder-samples-test-18'
+        libraryPackagePath = '\\\\ivy\\raid\\nuget-builder-samples-test'
     else:
-        libraryPackagePath = '/raid/nuget-builder-samples-test-18'
+        libraryPackagePath = '/raid/nuget-builder-samples-test'
 
     libraryPackages = [os.path.join(libraryPackagePath, item) for item in os.listdir(libraryPackagePath)]
 


### PR DESCRIPTION
Fulfills **JIRA issue** [APDFL-6789](https://datalogics-jira.atlassian.net/browse/APDFL-6789)

Updates the VB .NET samples to build and run against **APDFL 21**.

## Changes
- **Sample projects → APDFL 21 package**: bump `Adobe.PDF.Library.LM.NET` `PackageReference` from `18.*` to `21.*` across all 71 projects.
- **Retarget to net10.0**: APDFL 21's `Adobe.PDF.Library` packages ship the managed `Datalogics.PDFL` assembly under `lib/net10.0` only, so the `net8.0` projects could not resolve a reference. All 71 projects now target `net10.0`.
- **README**: point Documentation, API Reference, and Release Notes links at the APDFL 21 URLs (`apdfl21` / `adobe-pdf-library-21`).
- **tasks.py**: update the nightly and released package source paths to APDFL 21 (`for_apdfl_21.0.0Plus`; unsuffixed `nuget-builder-samples-test`).
- **Jenkinsfile**: run the nightly on `develop-21` (staggered to 08:00–08:30 so it doesn't collide with the develop-18 nightly on the shared NuGet cache), and move the Linux build agents to `rocky9-*-dotnet-samples`.

## Related
- Jenkins views (`develop-21` added to *Failed Jobs* and *PDFL and its dependencies*): separate PR in the **tycho** repo.

[APDFL-6789]: https://datalogics-jira.atlassian.net/browse/APDFL-6789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
