### PR TITLE
Set develop-18 nightly cron to a fixed 04:00 start

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,10 +14,7 @@ pipeline {
     }
     agent none
     triggers {
-        // Run branches between 0800 and 0830, depending on a hash of the job name
-        // This means if there's more than one branch (a feature branch, maybe?), they
-        // won't all start at the same time.
-        cron(env.BRANCH_NAME == "develop-18" ? 'H(0-30) 7 * * *' : '')
+        cron(env.BRANCH_NAME == "develop-18" ? '0 4 * * *' : '')
     }
     stages {
         stage('Matrix stage') {


### PR DESCRIPTION
- change the develop-18 cron from 'H(0-30) 7 * * *' to a fixed '0 4 * * *'
- remove the stale comment describing the old hashed 0800-0830 window

part of staggering the nightly sample builds so they run one at a time after nuget-builder (03:30) uploads packages, instead of clustering around 07:00-08:00.