### PR TITLE
Set develop-21 nightly cron to a fixed 04:45 start

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,10 +14,7 @@ pipeline {
     }
     agent none
     triggers {
-        // Run branches between 0800 and 0830, depending on a hash of the job name
-        // This means if there's more than one branch (a feature branch, maybe?), they
-        // won't all start at the same time.
-        cron(env.BRANCH_NAME == "develop-21" ? 'H(0-30) 8 * * *' : '')
+        cron(env.BRANCH_NAME == "develop-21" ? '45 4 * * *' : '')
     }
     stages {
         stage('Matrix stage') {


### PR DESCRIPTION
- change the develop-21 cron from 'H(0-30) 8 * * *' to a fixed '45 4 * * *'
- remove the stale comment describing the old hashed 0800-0830 window

part of staggering the nightly sample builds so they run one at a time after nuget-builder (03:30) uploads packages, instead of clustering around 07:00-08:00.